### PR TITLE
IntegerRange can now be instantiated using an Array.

### DIFF
--- a/lib/prolog/dry_types/integer_range.rb
+++ b/lib/prolog/dry_types/integer_range.rb
@@ -13,9 +13,9 @@ module Types
   # reflection, this makes little sense as a general-purpose behaviour, as it is
   # highly likely to surprise casual users.
   IntegerRange = Range.constructor do |value|
-    if value.is_a?(::Range)
-      value
-    else
+    if value.respond_to?(:minmax) # Enumerable; eg, Range or Array
+      value.min..value.max
+    else # it *better* be an Integer
       0..value.to_i
     end
   end

--- a/test/prolog/dry_types/integer_range_test.rb
+++ b/test/prolog/dry_types/integer_range_test.rb
@@ -27,6 +27,11 @@ describe 'Types::IntegerRange' do
       @range = 0..42
       @obj = attribute_class.new range: 42
     end
+
+    it 'an Array of integers representing a Range' do # See Issue #1.
+      @range = init_range
+      @obj = attribute_class.new range: init_range.to_a
+    end
   end # describe 'can be initialised with'
 
   describe 'when initialised with' do
@@ -38,6 +43,12 @@ describe 'Types::IntegerRange' do
     it 'an Integer, is a Range from 0 to that value, inclusive' do
       obj = attribute_class.new range: top_end
       expect(obj.range).must_equal 0..top_end
+    end
+
+    # See Issue #1.
+    it 'an Array of integers, is a Range spanning the values in that Array' do
+      obj = attribute_class.new range: init_range.to_a
+      expect(obj.range).must_equal init_range
     end
   end # describe 'when initialised with'
 end


### PR DESCRIPTION
As specified in Issue #1.

Necessitated by needing to support versions of the [`dry-types`](https://github.com/dry-rb/dry-types) Gem [later than](https://github.com/dry-rb/dry-types/releases) Version 0.7.2.
