### PR TITLE
Updating dependencies not covered in previous release.

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -6,16 +6,16 @@
 rm -rf gemset/ .rbenv-gemsets Gemfile.lock
 
 rbenv gemset init './gemset'
-gem install dry-types -v 0.9.2
+gem install dry-types -v 0.9.3
 gem install dry-struct -v 0.1.1
 gem install uuid -v 2.3.8
 
 gem install bundler -v 1.13.6
 gem install rake -v 11.3.0
-gem install minitest -v 5.9.1
+gem install minitest -v 5.10.1
 
 gem install minitest-matchers -v 1.4.1
-gem install minitest-reporters -v 1.1.12
+gem install minitest-reporters -v 1.1.13
 gem install minitest-tagz -v 1.5.2
 
 gem install flay -v 2.8.1

--- a/lib/prolog/dry_types/version.rb
+++ b/lib/prolog/dry_types/version.rb
@@ -3,6 +3,6 @@
 module Prolog
   # Container for RubyGems-required constant definitions.
   module DryTypes
-    VERSION = '0.3.1'
+    VERSION = '0.3.2'
   end
 end

--- a/prolog-dry_types.gemspec
+++ b/prolog-dry_types.gemspec
@@ -30,15 +30,15 @@ Gem::Specification.new do |spec|
   spec.require_paths         = ["lib"]
 
   spec.add_dependency "dry-struct", "0.1.1"
-  spec.add_dependency "dry-types", "0.9.2"
+  spec.add_dependency "dry-types", "0.9.3"
   spec.add_dependency "uuid", "2.3.8"
 
   spec.add_development_dependency "bundler", "1.13.6"
   spec.add_development_dependency "rake", "11.3.0"
-  spec.add_development_dependency "minitest", "5.9.1"
+  spec.add_development_dependency "minitest", "5.10.1"
 
   spec.add_development_dependency "minitest-matchers", "1.4.1"
-  spec.add_development_dependency "minitest-reporters", "1.1.12"
+  spec.add_development_dependency "minitest-reporters", "1.1.13"
   spec.add_development_dependency "minitest-tagz", "1.5.2"
 
   spec.add_development_dependency "awesome_print", "1.7.0"


### PR DESCRIPTION
[Closes #7]

* `minitest` 5.9.1 -> 5.10.1
* `minitest-reporters` 1.1.12 -> 1.1.13
* `dry-types` 0.9.2 -> 0.9.3
